### PR TITLE
feat(document): update Document and DocumentAction entities

### DIFF
--- a/src/main/java/mk/ukim/finki/routingsystem/model/documentEntities/Document.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/documentEntities/Document.java
@@ -42,7 +42,12 @@ public class Document {
     private Set<Employee> routedToEmployees = new HashSet<>();
 
     @OneToMany (mappedBy = "document", fetch = FetchType.LAZY, cascade=CascadeType.ALL, orphanRemoval=true)
-    private List<DocumentVersion> documentVersions = new ArrayList<>();
+    @OrderBy("versionNumber DESC")
+    private List<DocumentVersion> allDocumentVersions = new ArrayList<>();
+
+    @OneToOne (fetch = FetchType.LAZY)
+    @JoinColumn (nullable = false)
+    private DocumentVersion currentDocumentVersion;
 
     @Enumerated (EnumType.STRING)
     private DocumentStatus documentStatus;
@@ -50,13 +55,25 @@ public class Document {
     public Document() {
     }
 
-    public Document(String title, Employee uploadedByEmployee, LocalDateTime uploadDateTime, Department routedToDepartment, Set<Employee> routedToEmployees, List<DocumentVersion> documentVersions, DocumentStatus documentStatus) {
+    public Document(String title, Employee uploadedByEmployee, LocalDateTime uploadDateTime, Department routedToDepartment, Set<Employee> routedToEmployees, List<DocumentVersion> allDocumentVersions, DocumentVersion currentDocumentVersion, DocumentStatus documentStatus) {
         this.title = title;
         this.uploadedByEmployee = uploadedByEmployee;
         this.uploadDateTime = uploadDateTime;
         this.routedToDepartment = routedToDepartment;
         this.routedToEmployees = routedToEmployees;
-        this.documentVersions = documentVersions;
+        this.allDocumentVersions = allDocumentVersions;
+        this.currentDocumentVersion = currentDocumentVersion;
         this.documentStatus = documentStatus;
+    }
+
+    public void addVersion(DocumentVersion documentVersion) {
+        if (documentVersion != null) {
+            // sets the FK value of the document for the new documentVersion
+            documentVersion.setDocument(this);
+            // keeps the in-memory object graph consistent
+            // immediately includes the new version (without needing to reload the DB)
+            this.allDocumentVersions.add(documentVersion);
+            this.currentDocumentVersion = documentVersion;
+        }
     }
 }

--- a/src/main/java/mk/ukim/finki/routingsystem/model/documentEntities/DocumentAction.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/documentEntities/DocumentAction.java
@@ -30,7 +30,7 @@ public class DocumentAction {
     private Employee performedByEmployee;
 
     @Enumerated(EnumType.STRING)
-    @JoinColumn(nullable=false)
+    @Column(nullable=false)
     private ActionType performedAction;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
### feat(document): add currentDocumentVersion relation for quick access to latest version in Document entity and update DocumentAction entity

- Introduce OneToOne relation from Document to its current DocumentVersion
- Keep allDocumentVersions for full history, ordered by versionNumber
- Add helper method addVersion() to sync FK, in-memory list and current pointer