### PR TITLE
feat(dto): introduce DTOs for documents, versions, actions and downloads

### DIFF
--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/AdminRoutedDocumentDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/AdminRoutedDocumentDto.java
@@ -1,0 +1,15 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminRoutedDocumentDto(
+
+        Long documentId,
+        String title,
+        String uploadedByEmployee,
+        String routedToDepartment,
+        LocalDateTime uploadedDateTime,
+        String documentStatus,
+        String currentVersion,
+        String currentVersionDownloadUrl
+) {}

--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentActionDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentActionDto.java
@@ -1,0 +1,17 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+import java.time.LocalDateTime;
+
+public record DocumentActionDto(
+
+        Long actionId,
+        Long documentId,
+        String documentVersion,
+        String performedByEmployee,
+        String actionType,
+        String fromStatus,
+        String toStatus,
+        String note,
+        LocalDateTime dateTime
+
+) { }

--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentDownloadDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentDownloadDto.java
@@ -1,0 +1,12 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+import java.time.LocalDateTime;
+
+public record DocumentDownloadDto(
+        Long downloadId,
+        Long documentId,
+        String documentTitle,
+        String employee,
+        String versionNumber,
+        LocalDateTime downloadedAt
+) {}

--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentVersionHistoryDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/DocumentVersionHistoryDto.java
@@ -1,0 +1,14 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+import java.time.LocalDateTime;
+
+public record DocumentVersionHistoryDto(
+
+        Long versionId,
+        String versionNumber,
+        String editedBy,
+        String changeNote,
+        LocalDateTime uploadedDateTime,
+        String downloadUrl
+
+        ) {}

--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/EmployeeDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/EmployeeDto.java
@@ -1,0 +1,13 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+public record EmployeeDto(
+
+        Long employeeId,
+        String email,
+        String firstName,
+        String lastName,
+        String department,
+        String role,
+        String employeeType
+
+) {}

--- a/src/main/java/mk/ukim/finki/routingsystem/model/dto/RoutedDocumentDto.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/model/dto/RoutedDocumentDto.java
@@ -1,0 +1,15 @@
+package mk.ukim.finki.routingsystem.model.dto;
+
+import java.time.LocalDateTime;
+
+public record RoutedDocumentDto(
+        
+         Long documentId,
+         String title,
+         String uploadedByEmployee,
+         LocalDateTime uploadedDateTime,
+         String documentStatus,
+         String currentVersion,
+         String currentVersionDownloadUrl
+
+) {} 


### PR DESCRIPTION
### Summary
Introduce a set of Data Transfer Objects (DTOs) to decouple JPA entities from API responses and requests.

### Changes
- Added `RoutedDocumentDto` for employee “Received Documents” view  
- Added `AdminRoutedDocumentDto` for admin “All Routed Documents” overview  
- Added `DocumentVersionHistoryDto` for displaying past document versions  
- Added `DocumentDownloadDto` for tracking user and admin downloads  
- Added `DocumentActionDto` for listing routing, approval, rejection and edit actions  

### Notes
- Download links (`downloadUrl` / `currentVersionDownloadUrl`) are included for direct file retrieval  
