### PR TITLE
feat(service): add DepartmentService interface and implementation

### DIFF
--- a/src/main/java/mk/ukim/finki/routingsystem/service/DepartmentService.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/service/DepartmentService.java
@@ -1,0 +1,19 @@
+package mk.ukim.finki.routingsystem.service;
+
+import mk.ukim.finki.routingsystem.model.dto.DepartmentDto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DepartmentService {
+
+    List<DepartmentDto> listAll();
+
+    Optional<DepartmentDto> findById(Long departmentId);
+
+    DepartmentDto save(DepartmentDto departmentDto);
+
+    Optional<DepartmentDto> update(Long departmentId, DepartmentDto departmentDto);
+
+    boolean delete(Long departmentId);
+}

--- a/src/main/java/mk/ukim/finki/routingsystem/service/implementations/DepartmentServiceImpl.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/service/implementations/DepartmentServiceImpl.java
@@ -1,0 +1,74 @@
+package mk.ukim.finki.routingsystem.service.implementations;
+
+import mk.ukim.finki.routingsystem.model.Department;
+import mk.ukim.finki.routingsystem.model.dto.DepartmentDto;
+import mk.ukim.finki.routingsystem.repository.DepartmentRepository;
+import mk.ukim.finki.routingsystem.service.DepartmentService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DepartmentServiceImpl implements DepartmentService {
+
+
+    private final DepartmentRepository departmentRepository;
+
+    public DepartmentServiceImpl(DepartmentRepository departmentRepository) {
+        this.departmentRepository = departmentRepository;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<DepartmentDto> listAll() {
+
+        return departmentRepository.findAll()
+                .stream()
+                .map(d -> new DepartmentDto(d.getId(), d.getName()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Optional<DepartmentDto> findById(Long departmentId) {
+
+        return departmentRepository.findById(departmentId)
+                .map(d -> new DepartmentDto(d.getId(), d.getName()));
+    }
+
+    @Transactional
+    @Override
+    public DepartmentDto save(DepartmentDto departmentDto) {
+
+        Department savedDepartment = departmentRepository
+                .save(new Department(departmentDto.name()));
+
+        return new DepartmentDto(savedDepartment.getId(), savedDepartment.getName());
+
+    }
+
+    @Transactional
+    @Override
+    public Optional<DepartmentDto> update(Long departmentId, DepartmentDto departmentDto) {
+
+        return departmentRepository.findById(departmentId)
+                .map(d -> {
+                    d.setName(departmentDto.name());
+                    departmentRepository.save(d);
+                    return new DepartmentDto(d.getId(), d.getName());
+                });
+    }
+
+    @Transactional
+    @Override
+    public boolean delete(Long departmentId) {
+
+        if (!departmentRepository.existsById(departmentId)) return false;
+
+        departmentRepository.deleteById(departmentId);
+        return true;
+
+    }
+}


### PR DESCRIPTION
### Summary
Introduced the DepartmentService layer to handle business logic for department operations.

### Changes
- Added `DepartmentService` interface with CRUD-style method definitions.
- Implemented `DepartmentServiceImpl` with repository integration.
- Mapped `Department` entities to `DepartmentDto` for API exposure.
- Ensured save, update, and delete operations return Optional/boolean so controller decides responses.

### Notes
- Exceptions removed in favor of Optional/boolean contracts, allowing controller to map to proper HTTP status codes.

