### PR TITLE
feat(controller): add DepartmentRestController

### DIFF
--- a/src/main/java/mk/ukim/finki/routingsystem/web/DepartmentRestController.java
+++ b/src/main/java/mk/ukim/finki/routingsystem/web/DepartmentRestController.java
@@ -1,0 +1,68 @@
+package mk.ukim.finki.routingsystem.web;
+
+import mk.ukim.finki.routingsystem.model.dto.DepartmentDto;
+import mk.ukim.finki.routingsystem.service.DepartmentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping ("api/departments")
+public class DepartmentRestController {
+
+    private final DepartmentService departmentService;
+
+    public DepartmentRestController(DepartmentService departmentService) {
+        this.departmentService = departmentService;
+    }
+
+    @GetMapping
+    public List<DepartmentDto> listAll() {
+        return departmentService.listAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DepartmentDto> findById(@PathVariable Long id) {
+
+        return departmentService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+
+    }
+
+    @PostMapping
+    public ResponseEntity<DepartmentDto> save(@RequestBody DepartmentDto departmentDto) {
+
+        DepartmentDto saved = departmentService.save(departmentDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DepartmentDto> update(@PathVariable Long id ,@RequestBody DepartmentDto departmentDto) {
+
+        return departmentService.update(id, departmentDto)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+
+        boolean deleted = departmentService.delete(id);
+
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+
+    }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
### Summary
Introduced the DepartmentRestController to expose REST API endpoints for managing departments.

### Changes
- Added `DepartmentRestController` with CRUD endpoints under `/api/departments`.
- Integrated with `DepartmentService` for business logic.

### Notes
- Controller follows the project’s consistent pattern: service returns Optional/boolean, controller decides the HTTP response.

